### PR TITLE
Update NW.js and nw-builder - fix osx builds

### DIFF
--- a/dist.mjs
+++ b/dist.mjs
@@ -1,6 +1,6 @@
 import { copyFile, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { nwbuild } from 'nw-builder';
+import nwbuild from 'nw-builder';
 
 const packageManifest = JSON.parse(await readFile('./package.json'));
 const appBaseDir = path.resolve('./dist/app/');
@@ -51,6 +51,7 @@ for (const osType of appOsTypes) {
   const nwVersion = packageManifest.devDependencies.nw.split('-')[0] || defaultBuildCfg.nwVersion;
   const outDir = path.resolve(`./dist/${appName}-${appVersion}-${osType}/`);
   const nwBuildArgs = {
+    glob: false,
     srcDir: appBaseDir,
     version: nwVersion,
     flavour: 'normal',

--- a/main.js
+++ b/main.js
@@ -9,4 +9,4 @@ const interfaceUri = process.env.NWJS_START_URL
 
 const startUri = `${interfaceUri}/index.html`;
 
-nw.Window.open(startUri);
+nw.Window.open(startUri, { icon: './build/logo512.png' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "nw-react-example",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nw-react-example",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.4.3",
         "concurrently": "^7.5.0",
         "cross-env": "^7.0.3",
-        "nw": "0.70.1-sdk",
-        "nw-builder": "^4.0.1",
+        "nw": "0.72.0-sdk",
+        "nw-builder": "^4.2.1",
         "react": "^18.2.0",
         "react-devtools": "^4.26.1",
         "react-dom": "^18.2.0",
@@ -4096,6 +4096,16 @@
         "@types/range-parser": "*"
       }
     },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -4323,6 +4333,12 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
@@ -4478,16 +4494,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.30.0",
@@ -6317,9 +6323,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001361",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
-      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
+      "version": "1.0.30001470",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
+      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
       "dev": true,
       "funding": [
         {
@@ -6433,15 +6439,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -6494,9 +6491,9 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.3"
@@ -10199,18 +10196,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/fs-monkey": {
@@ -14621,31 +14606,6 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
-    "node_modules/minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -14827,9 +14787,9 @@
       }
     },
     "node_modules/nw": {
-      "version": "0.70.1-sdk",
-      "resolved": "https://registry.npmjs.org/nw/-/nw-0.70.1-sdk.tgz",
-      "integrity": "sha512-AFpTxIVZldtxTT5rKN/L4Wgzyq3hybOrwGIPbHV9OP5HyCnTrZ/0A8UdxfCKy5mWyqu/meTtMG+QxmTyxeOYOQ==",
+      "version": "0.72.0-sdk",
+      "resolved": "https://registry.npmjs.org/nw/-/nw-0.72.0-sdk.tgz",
+      "integrity": "sha512-/tVUlGVXWkJfobGAlBoD/bYXOWHthNPKpzgcinhayik0dAjoAoUxgur5YE65Xl64lKcAzg3a/COt3JwqHDT7zw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -14848,23 +14808,32 @@
       }
     },
     "node_modules/nw-builder": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nw-builder/-/nw-builder-4.0.1.tgz",
-      "integrity": "sha512-+YOS4KZx2Lo/qzFO01t1XSe/iOLmh2b4iHZW+IgOxxzQN5m8aFcU8af8UQ+DJH22uChi+QvxlEa3JZxzn84iRw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/nw-builder/-/nw-builder-4.2.1.tgz",
+      "integrity": "sha512-2mC3doLcOATp4+R8UdzKVjWrvLLV5WAuB+nXT9n5DYJUDYoRwSjDNhtFS4AdI+E9DN436f/YPpN3QrIsx65zTg==",
       "dev": true,
       "dependencies": {
         "archiver": "^5.3.1",
-        "cli-progress": "^3.11.2",
-        "extract-zip": "^2.0.1",
+        "cli-progress": "^3.12.0",
+        "decompress": "^4.2.1",
+        "glob-promise": "^6.0.2",
         "plist": "^3.0.6",
-        "progress": "^2.0.3",
         "rcedit": "^3.0.1",
-        "tar": "^6.1.11",
         "winston": "^3.8.2",
-        "yargs": "^17.5.1"
+        "yargs": "^17.7.1"
       },
       "bin": {
         "nwbuild": "src/cli.js"
+      }
+    },
+    "node_modules/nw-builder/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/nw-builder/node_modules/cliui": {
@@ -14881,45 +14850,62 @@
         "node": ">=12"
       }
     },
-    "node_modules/nw-builder/node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+    "node_modules/nw-builder/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/nw-builder/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/nw-builder/node_modules/glob-promise": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-6.0.2.tgz",
+      "integrity": "sha512-Ni2aDyD1ekD6x8/+K4hDriRDbzzfuK4yKpqSymJ4P7IxbtARiOOuU+k40kbHM0sLIlbf1Qh0qdMkAHMZYE6XJQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/ahmadnassri"
+      },
+      "peerDependencies": {
+        "glob": "^8.0.3"
+      }
+    },
+    "node_modules/nw-builder/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/nw-builder/node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -19397,23 +19383,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tar": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.12.tgz",
-      "integrity": "sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
@@ -19454,18 +19423,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/temp-dir": {
@@ -24355,6 +24312,16 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -24544,6 +24511,12 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
@@ -24699,16 +24672,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
-    },
-    "@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.30.0",
@@ -26109,9 +26072,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001361",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz",
-      "integrity": "sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==",
+      "version": "1.0.30001470",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
+      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -26188,12 +26151,6 @@
         }
       }
     },
-    "chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true
-    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -26236,9 +26193,9 @@
       "dev": true
     },
     "cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.3"
@@ -29042,15 +28999,6 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
-      }
-    },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0"
       }
     },
     "fs-monkey": {
@@ -32369,25 +32317,6 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
-    "minipass": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.4.tgz",
-      "integrity": "sha512-I9WPbWHCGu8W+6k1ZiGpPu0GkoKBeorkfKNuAFBNS1HNFJvke82sxvI5bzcCNpWPorkOO5QQ+zomzzwRxejXiw==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      }
-    },
     "mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -32526,9 +32455,9 @@
       "dev": true
     },
     "nw": {
-      "version": "0.70.1-sdk",
-      "resolved": "https://registry.npmjs.org/nw/-/nw-0.70.1-sdk.tgz",
-      "integrity": "sha512-AFpTxIVZldtxTT5rKN/L4Wgzyq3hybOrwGIPbHV9OP5HyCnTrZ/0A8UdxfCKy5mWyqu/meTtMG+QxmTyxeOYOQ==",
+      "version": "0.72.0-sdk",
+      "resolved": "https://registry.npmjs.org/nw/-/nw-0.72.0-sdk.tgz",
+      "integrity": "sha512-/tVUlGVXWkJfobGAlBoD/bYXOWHthNPKpzgcinhayik0dAjoAoUxgur5YE65Xl64lKcAzg3a/COt3JwqHDT7zw==",
       "dev": true,
       "requires": {
         "chalk": "~1.1.3",
@@ -32668,22 +32597,31 @@
       }
     },
     "nw-builder": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nw-builder/-/nw-builder-4.0.1.tgz",
-      "integrity": "sha512-+YOS4KZx2Lo/qzFO01t1XSe/iOLmh2b4iHZW+IgOxxzQN5m8aFcU8af8UQ+DJH22uChi+QvxlEa3JZxzn84iRw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/nw-builder/-/nw-builder-4.2.1.tgz",
+      "integrity": "sha512-2mC3doLcOATp4+R8UdzKVjWrvLLV5WAuB+nXT9n5DYJUDYoRwSjDNhtFS4AdI+E9DN436f/YPpN3QrIsx65zTg==",
       "dev": true,
       "requires": {
         "archiver": "^5.3.1",
-        "cli-progress": "^3.11.2",
-        "extract-zip": "^2.0.1",
+        "cli-progress": "^3.12.0",
+        "decompress": "^4.2.1",
+        "glob-promise": "^6.0.2",
         "plist": "^3.0.6",
-        "progress": "^2.0.3",
         "rcedit": "^3.0.1",
-        "tar": "^6.1.11",
         "winston": "^3.8.2",
-        "yargs": "^17.5.1"
+        "yargs": "^17.7.1"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "cliui": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -32695,31 +32633,43 @@
             "wrap-ansi": "^7.0.0"
           }
         },
-        "extract-zip": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-          "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "dev": true,
+          "peer": true,
           "requires": {
-            "@types/yauzl": "^2.9.1",
-            "debug": "^4.1.1",
-            "get-stream": "^5.1.0",
-            "yauzl": "^2.10.0"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+        "glob-promise": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-6.0.2.tgz",
+          "integrity": "sha512-Ni2aDyD1ekD6x8/+K4hDriRDbzzfuK4yKpqSymJ4P7IxbtARiOOuU+k40kbHM0sLIlbf1Qh0qdMkAHMZYE6XJQ==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "@types/glob": "^8.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         },
         "yargs": {
-          "version": "17.6.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "version": "17.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
           "dev": true,
           "requires": {
             "cliui": "^8.0.1",
@@ -35856,28 +35806,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "dev": true
-    },
-    "tar": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.12.tgz",
-      "integrity": "sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==",
-      "dev": true,
-      "requires": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        }
-      }
     },
     "tar-stream": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nw-react-example",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "main.js",
   "homepage": ".",
   "node-remote": [
@@ -14,8 +14,8 @@
     "@testing-library/user-event": "^14.4.3",
     "concurrently": "^7.5.0",
     "cross-env": "^7.0.3",
-    "nw": "0.70.1-sdk",
-    "nw-builder": "^4.0.1",
+    "nw": "0.72.0-sdk",
+    "nw-builder": "^4.2.1",
     "react": "^18.2.0",
     "react-devtools": "^4.26.1",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Note that NW.js 0.72 is used instead of 0.74, since taskbar icons are broken in 0.73 and 0.74.